### PR TITLE
Update aurora.css

### DIFF
--- a/templates/assets/css/aurora.css
+++ b/templates/assets/css/aurora.css
@@ -1273,7 +1273,7 @@ img, video {
     width: 1em;
     margin-left: -1.5em;
     margin-right: .5em;
-    text-align: right;
+    text-align: left;
     direction: rtl;
     overflow: visible;
     word-break: keep-all;

--- a/templates/assets/css/aurora.css
+++ b/templates/assets/css/aurora.css
@@ -1266,7 +1266,7 @@ img, video {
 }
 
 .post-html ol > li:before, .post-html ul ol > li:before, .post-html ul ul ol > li:before, .post-html ul ul ul ol > li:before {
-    content: "." counter(li);
+    content: "." counter(list-item);
     color: var(--text-accent);
     font-weight: 400;
     display: inline-block;


### PR DESCRIPTION
在编辑器：
![1a30cb3156fedebe85cd089afc69447c](https://github.com/user-attachments/assets/e3d1b1e5-f0ed-4e90-8ab8-25d0ef6836d7)
但是渲染为：
![22ca634239860962797342f5de4e7938](https://github.com/user-attachments/assets/d153b575-0421-4985-be47-5c81fefcb260)
可以发现有序列表的顺序计数出现问题。

切换到默认主题和其他主题发现均加载正常，猜测应该是主题问题。

翻 css 文件看到 `counter(li)`，使用 `counter(list-item)` 后恢复正常。

![image](https://github.com/user-attachments/assets/43e147dc-7ae8-4b41-87e5-faf3dd89bc65)
